### PR TITLE
Add mode name to minor modes tooltip

### DIFF
--- a/rich-minority.el
+++ b/rich-minority.el
@@ -177,15 +177,27 @@ These properties take priority over those defined in
 (defvar-local rm--help-echo nil
   "Used to set the help-echo string dynamically.")
 
+(defun rm-format-mode-line-entry (entry)
+  "Format an ENTRY of `minor-mode-alist'.
+Return a cons of the mode line string and the mode name, or nil
+if the mode line string is empty."
+  (let ((mode-symbol (car entry))
+        (mode-string (format-mode-line entry)))
+    (unless (string= mode-string "")
+      (cons mode-string mode-symbol))))
+
 ;;;###autoload
 (defun rm--mode-list-as-string-list ()
   "Return `minor-mode-list' as a simple list of strings."
-  (let ((full-list (delete "" (mapcar #'format-mode-line minor-mode-alist))))
+  (let ((full-list (delq nil (mapcar #'rm-format-mode-line-entry
+                                     minor-mode-alist))))
     (setq rm--help-echo
-          (format "Full list:\n   %s\n\n%s"
-                  (mapconcat 'identity full-list "\n   ")
+          (format "Full list:\n%s\n\n%s"
+                  (mapconcat (lambda (pair)
+                               (format "   %s (%S)" (car pair) (cdr pair)))
+                             full-list "\n")
                   rm--help-echo-bottom))
-    (mapcar #'rm--propertize
+    (mapcar (lambda (pair) (rm--propertize (car pair)))
             (rm--remove-hidden-modes full-list))))
 
 (defcustom rm-base-text-properties


### PR DESCRIPTION
Changes the minor mode tooltip from
```
  Full list:
    Spell
    Out
    Ovwrt
```
to
```
  Full list:
    Spell (ispell-mode)
    Out (outline-mode)
    Ovwrt (overwrite-mode)
```
This is especially useful when trying to identify a mode from its mode line string.