### PR TITLE
Fix alignment of mode names in tooltip

### DIFF
--- a/rich-minority.el
+++ b/rich-minority.el
@@ -190,11 +190,13 @@ if the mode line string is empty."
 (defun rm--mode-list-as-string-list ()
   "Return `minor-mode-list' as a simple list of strings."
   (let ((full-list (delq nil (mapcar #'rm-format-mode-line-entry
-                                     minor-mode-alist))))
+                                     minor-mode-alist)))
+        (spacer (propertize " " 'display '(space :align-to 15))))
     (setq rm--help-echo
           (format "Full list:\n%s\n\n%s"
                   (mapconcat (lambda (pair)
-                               (format "   %-15s (%S)" (car pair) (cdr pair)))
+                               (format "   %s%s(%S)"
+                                       (car pair) spacer (cdr pair)))
                              full-list "\n")
                   rm--help-echo-bottom))
     (mapcar #'rm--propertize


### PR DESCRIPTION
This is useful when lighters include wide characters.

This is before:
![regular-spacing](https://cloud.githubusercontent.com/assets/8181630/17112522/5a5e1b28-5274-11e6-9c0a-f255e25edbe7.png)

And this is after:
![proper-spacing](https://cloud.githubusercontent.com/assets/8181630/17112523/5a5e9666-5274-11e6-8f59-cc894ede98e5.png)
