### PR TITLE
Silence byte compilation warning

### DIFF
--- a/rich-minority.el
+++ b/rich-minority.el
@@ -97,6 +97,8 @@ Please include your Emacs and rich-minority versions."
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Customization variables.
+(define-obsolete-variable-alias 'rm-excluded-modes 'rm-blacklist "0.1.1")
+(define-obsolete-variable-alias 'rm-hidden-modes 'rm-blacklist "0.1.1")
 (defcustom rm-blacklist '(" hl-p")
   "List of minor modes you want to hide from the mode-line.
 
@@ -122,9 +124,8 @@ minor-mode lighters start with a space."
                  (regexp :tag "Regular expression."))
   :group 'rich-minority
   :package-version '(rich-minority . "0.1.1"))
-(define-obsolete-variable-alias 'rm-excluded-modes 'rm-blacklist "0.1.1")
-(define-obsolete-variable-alias 'rm-hidden-modes 'rm-blacklist "0.1.1")
 
+(define-obsolete-variable-alias 'rm-included-modes 'rm-whitelist "0.1.1")
 (defcustom rm-whitelist nil
   "List of minor modes you want to include in the mode-line.
 
@@ -149,7 +150,6 @@ minor-mode lighters start with a space."
                  (regexp :tag "Regular expression."))
   :group 'rich-minority
   :package-version '(rich-minority . "0.1.1"))
-(define-obsolete-variable-alias 'rm-included-modes 'rm-whitelist "0.1.1")
 
 (defcustom rm-text-properties
   '(("\\` Ovwrt\\'" 'face 'font-lock-warning-face))


### PR DESCRIPTION
See https://github.com/emacs-mirror/emacs/blob/3ff7d7321ac62b1eb896e8a032e7f75f5a6b8146/lisp/emacs-lisp/bytecomp.el#L2449

```
  ;; Variable aliases are better declared before the corresponding variable,
  ;; since it makes it more likely that only one of the two vars has a value
  ;; before the `defvaralias' gets executed, which avoids the need to
  ;; merge values.
```

The warnings I was getting were harmless, I just wanted to silence them anyway.
```
rich-minority.el:126:1:Warning: Alias for ‘rm-blacklist’ should be declared
    before its referent
rich-minority.el:127:1:Warning: Alias for ‘rm-blacklist’ should be declared
    before its referent
rich-minority.el:153:1:Warning: Alias for ‘rm-whitelist’ should be declared
    before its referent
```